### PR TITLE
Use relative import and rename xdelta module.

### DIFF
--- a/snapcraft/internal/deltas/__init__.py
+++ b/snapcraft/internal/deltas/__init__.py
@@ -15,4 +15,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from snapcraft.internal.deltas._xdelta_deltas import XdeltaGenerator # noqa
+from ._xdelta import XDeltaGenerator # noqa

--- a/snapcraft/internal/deltas/_xdelta.py
+++ b/snapcraft/internal/deltas/_xdelta.py
@@ -24,7 +24,7 @@ from snapcraft.internal.deltas import BaseDeltasGenerator
 logger = logging.getLogger(__name__)
 
 
-class XdeltaGenerator(BaseDeltasGenerator):
+class XDeltaGenerator(BaseDeltasGenerator):
 
     delta_format = 'xdelta'
     delta_tool_path = '/usr/bin/xdelta'


### PR DESCRIPTION
Since we're already in the deltas package, I think you can just call the module _xdelta.py

I've also renamed XdeltaGenerator to XDeltaGenerator to make it consistent with Snap Delta Service.